### PR TITLE
Feature/up 2007 request id refactoring

### DIFF
--- a/src/main/scala/com/ubirch/messageauth/MessageAuthMicroservice.scala
+++ b/src/main/scala/com/ubirch/messageauth/MessageAuthMicroservice.scala
@@ -13,20 +13,20 @@ class MessageAuthMicroservice(authCheckerFactory: NioMicroservice.Context => Aut
   val authorizedTopic: String = outputTopics("authorized")
   val unauthorizedTopic: String = outputTopics("unauthorized")
 
-  def processRecord(input: ConsumerRecord[String, Array[Byte]]): ProducerRecord[String, Array[Byte]] = {
+  def processRecord(record: ConsumerRecord[String, Array[Byte]]): ProducerRecord[String, Array[Byte]] = {
 
-    val requestId = input.requestIdHeader().orNull
+    val requestId = record.requestIdHeader().orNull
 
-    val CheckResult(rejectionReason, headersToAdd) = checkAuth(input.headersScala)
+    val CheckResult(rejectionReason, headersToAdd) = checkAuth(record.headersScala)
 
     rejectionReason match {
       case None =>
         logger.info(s"request [{}] is authorized", v("requestId", requestId))
-        input.toProducerRecord(authorizedTopic).withExtraHeaders(headersToAdd.toSeq: _*)
+        record.toProducerRecord(authorizedTopic).withExtraHeaders(headersToAdd.toSeq: _*)
       case Some(reason) =>
         logger.info(s"request [{}] is NOT authorized; reason: {}", v("requestId", requestId),
           v("notAuthorizedReason", reason.getMessage))
-        input.toProducerRecord(unauthorizedTopic).withExtraHeaders("http-status-code" -> "401")
+        record.toProducerRecord(unauthorizedTopic).withExtraHeaders("http-status-code" -> "401")
     }
   }
 }

--- a/src/main/scala/com/ubirch/messageauth/MessageAuthMicroservice.scala
+++ b/src/main/scala/com/ubirch/messageauth/MessageAuthMicroservice.scala
@@ -9,6 +9,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 
 class MessageAuthMicroservice(authCheckerFactory: NioMicroservice.Context => AuthChecker, runtime: NioMicroservice[Array[Byte], Array[Byte]])
   extends NioMicroserviceLogic[Array[Byte], Array[Byte]](runtime) {
+
   val checkAuth: AuthChecker = authCheckerFactory(context)
   val authorizedTopic: String = outputTopics("authorized")
   val unauthorizedTopic: String = outputTopics("unauthorized")
@@ -24,10 +25,10 @@ class MessageAuthMicroservice(authCheckerFactory: NioMicroservice.Context => Aut
         logger.info(s"request [{}] is authorized", v("requestId", requestId))
         record.toProducerRecord(authorizedTopic).withExtraHeaders(headersToAdd.toSeq: _*)
       case Some(reason) =>
-        logger.info(s"request [{}] is NOT authorized; reason: {}", v("requestId", requestId),
-          v("notAuthorizedReason", reason.getMessage))
+        logger.info(s"request [{}] is NOT authorized; reason: {}", v("requestId", requestId), v("notAuthorizedReason", reason.getMessage))
         record.toProducerRecord(unauthorizedTopic).withExtraHeaders("http-status-code" -> "401")
     }
+
   }
 }
 

--- a/src/test/scala/com/ubirch/messageauth/MessageAuthTest.scala
+++ b/src/test/scala/com/ubirch/messageauth/MessageAuthTest.scala
@@ -8,14 +8,12 @@ import com.ubirch.messageauth.AuthCheckers.CheckResult
 import com.ubirch.niomon.base.{NioMicroservice, NioMicroserviceMock}
 import com.ubirch.niomon.util.EnrichedMap.toEnrichedMap
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.apache.kafka.common.header.Header
-import org.apache.kafka.common.header.internals.RecordHeader
+import com.ubirch.kafka.RichAnyProducerRecord
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringDeserializer}
 import org.nustaq.serialization.FSTConfiguration
 import org.redisson.codec.FstCodec
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
-import scala.collection.JavaConverters._
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 
@@ -162,7 +160,6 @@ class MessageAuthTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     NioMicroserviceMock(MessageAuthMicroservice(checkerFactory))
 
   private def arbitraryRecordWithHeaders(topic: String, headers: (String, String)*): ProducerRecord[String, Array[Byte]] =
-    new ProducerRecord[String, Array[Byte]](topic, null, null, "key", "value".getBytes(UTF_8),
-      (for {(k, v) <- headers} yield new RecordHeader(k, v.getBytes(UTF_8)): Header).toList.asJava
-    )
+    new ProducerRecord[String, Array[Byte]](topic, "value".getBytes(UTF_8)).withHeaders(headers : _ *)
+
 }


### PR DESCRIPTION
Using the request id as part of the key field for a producer record values makes the partitioning of the data to be unbalanced. This PR moves the request id from the key to a header in the record.  