### PR TITLE
UP-2155 removing-purge-header and ; (not needed here)

### DIFF
--- a/src/main/scala/com/ubirch/messageauth/HeaderKeys.scala
+++ b/src/main/scala/com/ubirch/messageauth/HeaderKeys.scala
@@ -1,15 +1,14 @@
 package com.ubirch.messageauth
 
 object HeaderKeys {
-  val XUBIRCHCREDENTIAL: String = "X-Ubirch-Credential".toLowerCase;
-  val XUBIRCHHARDWAREID: String = "X-Ubirch-Hardware-Id".toLowerCase;
-  val XUBIRCHAUTHTYPE: String = "X-Ubirch-Auth-Type".toLowerCase;
-  val XUBIRCHDEVICEINFOTOKEN: String = "X-Ubirch-DeviceInfo-Token".toLowerCase;
-  val AUTHORIZATION: String = "Authorization".toLowerCase;
-  val XXSRFTOKEN: String = "X-XSRF-TOKEN".toLowerCase;
-  val XCUMULOCITYBASEURL: String = "X-Cumulocity-BaseUrl".toLowerCase;
-  val XCUMULOCITYTENANT: String = "X-Cumulocity-Tenant".toLowerCase;
-  val XNIOMONPURGECACHES: String = "X-Niomon-Purge-Caches".toLowerCase;
-  val CONTENTTYPE: String = "Content-Type".toLowerCase;
-  val COOKIE: String = "Cookie".toLowerCase;
+  val XUBIRCHCREDENTIAL: String = "X-Ubirch-Credential".toLowerCase
+  val XUBIRCHHARDWAREID: String = "X-Ubirch-Hardware-Id".toLowerCase
+  val XUBIRCHAUTHTYPE: String = "X-Ubirch-Auth-Type".toLowerCase
+  val XUBIRCHDEVICEINFOTOKEN: String = "X-Ubirch-DeviceInfo-Token".toLowerCase
+  val AUTHORIZATION: String = "Authorization".toLowerCase
+  val XXSRFTOKEN: String = "X-XSRF-TOKEN".toLowerCase
+  val XCUMULOCITYBASEURL: String = "X-Cumulocity-BaseUrl".toLowerCase
+  val XCUMULOCITYTENANT: String = "X-Cumulocity-Tenant".toLowerCase
+  val CONTENTTYPE: String = "Content-Type".toLowerCase
+  val COOKIE: String = "Cookie".toLowerCase
 }


### PR DESCRIPTION
We currently support the header x-niomon-purge-caches as part of Niomon. This header basically deletes the entries in the cache for the corresponding niomon system that support redis.
We have decided to remove the header completely and not allow this feature to be part of the system. It is not the responsibility of Niomon to purge caches based on a token. In case of purging, a direct connection to redis could allow the proper user/admin to log in and purge.