### PR TITLE
Payload as bytes - Parent POM fix - Scala Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.ubirch.niomon</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>
 


### PR DESCRIPTION
UP-1885 Support for payload as bytes for success with requestId
UP-2301 Fix to parent reference.
UP-2302 Fix Scala incompatibility with internal lib. Scala upgrade.